### PR TITLE
feat: add failure hook support to conformance report

### DIFF
--- a/conformance/apis/v1/conformancereport.go
+++ b/conformance/apis/v1/conformancereport.go
@@ -46,6 +46,19 @@ type ConformanceReport struct {
 	// ProfileReports is a list of the individual reports for each conformance
 	// profile that was enabled for a test run.
 	ProfileReports []ProfileReport `json:"profiles"`
+
+	FailureHookReports []FailureHookReports `json:"failureHookReports"`
+}
+
+type FailureHookReports struct {
+	Name    string // test name
+	Reports []FailureHookReport
+}
+
+// FailureHookReport for per test name
+type FailureHookReport struct {
+	Name   string // for hook
+	Output string
 }
 
 // Implementation provides metadata information on the downstream

--- a/conformance/utils/suite/conformance.go
+++ b/conformance/utils/suite/conformance.go
@@ -40,7 +40,7 @@ type ConformanceTest struct {
 
 // Run runs an individual tests, applying and cleaning up the required manifests
 // before calling the Test function.
-func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) string {
+func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) FailureHookResult {
 	if test.Parallel {
 		t.Parallel()
 	}
@@ -68,7 +68,7 @@ func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) stri
 
 	test.Test(t, suite)
 
-	var out string
+	out := make(FailureHookResult)
 	for _, hook := range suite.FailureHooks {
 		tlog.Logf(t, "Executing failure hook: %s", hook.Name)
 
@@ -78,7 +78,7 @@ func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) stri
 			tlog.Errorf(t, "Error while executing failure hook: %s", hook.Name)
 		}
 
-		out = out + "\n" + string(ret)
+		out[hook.Name] = ret
 	}
 
 	return out

--- a/conformance/utils/suite/conformance.go
+++ b/conformance/utils/suite/conformance.go
@@ -17,6 +17,7 @@ limitations under the License.
 package suite
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -39,7 +40,7 @@ type ConformanceTest struct {
 
 // Run runs an individual tests, applying and cleaning up the required manifests
 // before calling the Test function.
-func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
+func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) string {
 	if test.Parallel {
 		t.Parallel()
 	}
@@ -66,6 +67,21 @@ func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
 	}
 
 	test.Test(t, suite)
+
+	var out string
+	for _, hook := range suite.FailureHooks {
+		tlog.Logf(t, "Executing failure hook: %s", hook.Name)
+
+		cmd := exec.Command(hook.Path, hook.Args...)
+		ret, err := cmd.Output()
+		if err != nil {
+			tlog.Errorf(t, "Error while executing failure hook: %s", hook.Name)
+		}
+
+		out = out + "\n" + string(ret)
+	}
+
+	return out
 }
 
 // ParseSupportedFeatures parses flag arguments and converts the string to

--- a/conformance/utils/suite/reports.go
+++ b/conformance/utils/suite/reports.go
@@ -31,11 +31,12 @@ import (
 // -----------------------------------------------------------------------------
 
 type testResult struct {
-	test   ConformanceTest
-	result resultType
-	// report by failure hook exec
-	report string
+	test              ConformanceTest
+	result            resultType
+	failureHookReport FailureHookResult
 }
+
+type FailureHookResult map[string][]byte
 
 type resultType string
 

--- a/conformance/utils/suite/reports.go
+++ b/conformance/utils/suite/reports.go
@@ -33,6 +33,8 @@ import (
 type testResult struct {
 	test   ConformanceTest
 	result resultType
+	// report by failure hook exec
+	report string
 }
 
 type resultType string

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -27,7 +27,7 @@ const (
 
 	// BundleVersion is the value used for the "gateway.networking.k8s.io/bundle-version" annotation.
 	// These value must be updated during the release process.
-	BundleVersion = "v1.2.0-dev"
+	BundleVersion = "v1.1.0"
 
 	// ApprovalLink is the value used for the "api-approved.kubernetes.io" annotation.
 	// These value must be updated during the release process.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
